### PR TITLE
Project.toml updates

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,14 @@ TableTraits = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
 TableTraitsUtils = "382cd787-c1b6-5bf2-a167-d5b971a19bda"
 
 [compat]
+julia = "0.7, ^1"
 Bedgraph = "^1.1"
+FileIO = "^1.0.1"
+IteratorInterfaceExtensions = "^0.1.1, ^1"
+IterableTables = ">=0.9.0"
+TableShowUtils = "^0.2.0"
+TableTraits = "^0.4, ^1"
+TableTraitsUtils = "^0.3, ^0.4"
 
 [extras]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,8 +1,0 @@
-julia 0.7
-Bedgraph 1.1.0
-FileIO 1.0.1
-IterableTables 0.9.0
-IteratorInterfaceExtensions 0.1.1
-TableShowUtils 0.2.0
-TableTraits 0.4.0
-TableTraitsUtils 0.3.0

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,0 @@
-DataFrames 0.9.0


### PR DESCRIPTION
In particular, this now has the bounds information that is correct for the Queryverse packages. There will be a mega PR for the registry to also fix this for previous versions.